### PR TITLE
Handled not connected to an environment

### DIFF
--- a/js/drb.common.js
+++ b/js/drb.common.js
@@ -331,6 +331,10 @@ window.addEventListener("message", (event) => {
             var token = message.token;
             DRB.Common.RefreshDVDTToken(token);
             break;
+
+        case "dvdt_noconnection":
+            DRB.UI.ShowError("DVDT Connection Error", "You have not connected to any connection in Dataverse DevTools.");
+            break;
     }
 });
 // #endregion

--- a/js/drb_custom.js
+++ b/js/drb_custom.js
@@ -3944,6 +3944,10 @@ window.addEventListener("message", (event) => {
             var token = message.token;
             DRB.Common.RefreshDVDTToken(token);
             break;
+
+        case "dvdt_noconnection":
+            DRB.UI.ShowError("DVDT Connection Error", "You have not connected to any connection in Dataverse DevTools.");
+            break;
     }
 });
 // #endregion  


### PR DESCRIPTION
Added a sceanrio when user has not connected to an environment but opens DRB. The DRB will show an error inside the tool. Lemme know if you want DVDT to show that error outside and not load DRB at all. If you want the later please feel free to reject this PR.